### PR TITLE
Run the NSFetchedResultController on a PrivateQueueConcurrencyType context

### DIFF
--- a/RxCoreData/Sources/FetchedResultsControllerControllerEntityObserver.swift
+++ b/RxCoreData/Sources/FetchedResultsControllerControllerEntityObserver.swift
@@ -9,50 +9,71 @@
 import Foundation
 import CoreData
 import RxSwift
+import RxCocoa
 
 public final class FetchedResultsControllerEntityObserver : NSObject {
-    
-    typealias Observer = AnyObserver<[NSManagedObject]>
-    
-    let observer: Observer
-    let frc: NSFetchedResultsController
-    
-    init(observer: Observer, frc: NSFetchedResultsController) {
-        self.observer = observer
-        self.frc = frc
-        
-        super.init()
-        
-        self.frc.delegate = self
-        
-        do {
-            try self.frc.performFetch()
-        } catch let e {
-            observer.on(.Error(e))
-        }
-        
-        sendNextElement()
-    }
-    
-    private func sendNextElement() {
-        let entities = (self.frc.fetchedObjects as? [NSManagedObject]) ?? []
-        observer.on(.Next(entities))
-    }
-    
+	
+	typealias Observer = AnyObserver<[NSManagedObject]>
+	
+	let observer: Observer
+	let disposeBag = DisposeBag()
+	private let frc: NSFetchedResultsController
+	private let subscriberContext: NSManagedObjectContext
+	private let observingContext = NSManagedObjectContext(concurrencyType: .PrivateQueueConcurrencyType)
+	
+	init(observer: Observer, fetchRequest: NSFetchRequest, managedObjectContext context: NSManagedObjectContext, sectionNameKeyPath: String?, cacheName name: String?) {
+		self.observer = observer
+		self.subscriberContext = context
+		self.observingContext.parentContext = context
+		self.frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: observingContext, sectionNameKeyPath: sectionNameKeyPath, cacheName: name)
+		super.init()
+		
+		// TODO: Implement `automaticallyMergesChangesFromParent` whit iOs 10, instead of using NSManagedObjectContextDidSaveNotification
+		NSNotificationCenter.defaultCenter()
+			.rx_notification(NSManagedObjectContextDidSaveNotification, object: self.subscriberContext)
+			.subscribeNext() {
+				self.observingContext.mergeChangesFromContextDidSaveNotification($0)
+			}
+			.addDisposableTo(disposeBag)
+		
+		self.observingContext.performBlock {
+			self.frc.delegate = self
+			
+			do {
+				try self.frc.performFetch()
+			} catch let e {
+				observer.on(.Error(e))
+			}
+			
+			self.sendNextElement()
+		}
+	}
+	
+	private func sendNextElement() {
+		self.observingContext.performBlock {
+			let entities = (self.frc.fetchedObjects as? [NSManagedObject]) ?? []
+			self.subscriberContext.performBlock({
+				let mappedEntities = entities.map { self.subscriberContext.objectWithID($0.objectID)}
+				self.observer.on(.Next(mappedEntities))
+			})
+		}
+	}
+	
 }
 
 extension FetchedResultsControllerEntityObserver : NSFetchedResultsControllerDelegate {
-    
-    public func controllerDidChangeContent(controller: NSFetchedResultsController) {
-        sendNextElement()
-    }
-    
+	
+	public func controllerDidChangeContent(controller: NSFetchedResultsController) {
+		sendNextElement()
+	}
+	
 }
 
 extension FetchedResultsControllerEntityObserver : Disposable {
-    
-    public func dispose() {
-        frc.delegate = nil
-    }
-    
+	
+	public func dispose() {
+		frc.delegate = nil
+		NSNotificationCenter.defaultCenter().removeObserver(self)
+	}
+	
 }

--- a/RxCoreData/Sources/NSManagedObjectContext+Rx.swift
+++ b/RxCoreData/Sources/NSManagedObjectContext+Rx.swift
@@ -21,16 +21,15 @@ public extension NSManagedObjectContext {
      */
     func rx_entities(fetchRequest: NSFetchRequest, sectionNameKeyPath: String? = nil, cacheName: String? = nil) -> Observable<[NSManagedObject]> {
         return Observable.create { observer in
-            let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: self, sectionNameKeyPath: sectionNameKeyPath, cacheName: cacheName)
-            
-            let observerAdapter = FetchedResultsControllerEntityObserver(observer: observer, frc: frc)
-            
-            return AnonymousDisposable {
-                observerAdapter.dispose()
-            }
+			
+			let observerAdapter = FetchedResultsControllerEntityObserver(observer: observer, fetchRequest: fetchRequest, managedObjectContext: self, sectionNameKeyPath: sectionNameKeyPath, cacheName: cacheName)
+			
+			return AnonymousDisposable {
+				observerAdapter.dispose()
+			}
         }
     }
-    
+	
     /**
      Executes a fetch request and returns the fetched section objects as an `Observable` array of `NSFetchedResultsSectionInfo`.
      - parameter fetchRequest: an instance of `NSFetchRequest` to describe the search criteria used to retrieve data from a persistent store


### PR DESCRIPTION
Hi @scotteg 

This should fix the issue #7 
The behaviour implemented is the one described in this comment https://github.com/RxSwiftCommunity/RxCoreData/issues/7#issuecomment-226784513

Nothing changes in terms of usage, but when calling `rx_entities` on the Main Thread doesn't block it.

**Note:**
I also tried to implement `FetchedResultsControllerSectionObserver ` using the same concept, but I don't know if there is a way to convert a `NSFetchedResultsSectionInfo ` on a different context. I have an idea but we can discuss on it later.