### PR TITLE
Fix performUpdate

### DIFF
--- a/Sources/NSManagedObjectContext+Rx.swift
+++ b/Sources/NSManagedObjectContext+Rx.swift
@@ -61,12 +61,12 @@ public extension Reactive where Base: NSManagedObjectContext {
      - parameter updateAction: a throwing update action
      */
     func performUpdate(updateAction: (NSManagedObjectContext) throws -> Void) throws {
-        guard self.base.hasChanges else { return }
-        
         let privateContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         privateContext.parent = self.base
         
         try updateAction(privateContext)
+        
+        guard privateContext.hasChanges else { return }
         
         try privateContext.save()
         

--- a/Sources/NSManagedObjectContext+Rx.swift
+++ b/Sources/NSManagedObjectContext+Rx.swift
@@ -61,7 +61,7 @@ public extension Reactive where Base: NSManagedObjectContext {
      - parameter updateAction: a throwing update action
      */
     func performUpdate(updateAction: (NSManagedObjectContext) throws -> Void) throws {
-        let privateContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        let privateContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         privateContext.parent = self.base
         
         try updateAction(privateContext)


### PR DESCRIPTION
`performUpdate` would do nothing if there was no change in the base context.

Also, the saving was performed on the main queue.