### PR TITLE
Update Readme file pointing to the new RxSwiftCommunity repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RxCoreData
 
-[![CI Status](http://img.shields.io/travis/Scott Gardner/RxCoreData.svg?style=flat)](https://travis-ci.org/Scott Gardner/RxCoreData)
+[![CI Status](http://img.shields.io/travis/RxSwiftCommunity/RxCoreData.svg?style=flat)](https://travis-ci.org/RxSwiftCommunity/RxCoreData)
 [![Version](https://img.shields.io/cocoapods/v/RxCoreData.svg?style=flat)](http://cocoapods.org/pods/RxCoreData)
 [![License](https://img.shields.io/cocoapods/l/RxCoreData.svg?style=flat)](http://cocoapods.org/pods/RxCoreData)
 [![Platform](https://img.shields.io/cocoapods/p/RxCoreData.svg?style=flat)](http://cocoapods.org/pods/RxCoreData)


### PR DESCRIPTION
The badge was still pointing to the `https://travis-ci.org/Scott Gardner/RxCoreData` and it was looking bad on the readme file