### PR TITLE
Add mac 🖥, tv 📺 & watch ⌚️ support to Podspec

### DIFF
--- a/RxCoreData.podspec
+++ b/RxCoreData.podspec
@@ -22,10 +22,13 @@ Pod::Spec.new do |s|
     s.social_media_url      = "https://twitter.com/scotteg"
 
     s.ios.deployment_target = '8.0'
+    s.osx.deployment_target = '10.10'
+    s.watchos.deployment_target = '2.0'
+    s.tvos.deployment_target = '9.0'
 
     s.source_files = 'Sources/**/*'
 
-    s.frameworks            = 'UIKit', 'CoreData'
+    s.frameworks            = 'CoreData'
 
     s.dependency 'RxSwift', '~> 4.0'
     s.dependency 'RxCocoa', '~> 4.0'

--- a/RxCoreData.podspec
+++ b/RxCoreData.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
     s.source                = { :git => "https://github.com/RxSwiftCommunity/RxCoreData.git", :tag => s.version.to_s }
     s.social_media_url      = "https://twitter.com/scotteg"
 
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.10'
+    s.ios.deployment_target = '9.3'
+    s.osx.deployment_target = '10.11'
     s.watchos.deployment_target = '2.0'
     s.tvos.deployment_target = '9.0'
 


### PR DESCRIPTION
This small PR adds these 3x additional platforms onto the Podspec seeing as they all support Core Data.  I've assumed versions of these OSs released either around the same time or as near as possible in the case of watchOS and tvOS.  For watchOS and macOS, I've also removed the dependency on UIKit on there.

I'm hoping to add the same for Carthage, but let's take this one step at a time.