### PR TITLE
Bump macOS requirement to Sierra (10.12) in podspec

### DIFF
--- a/RxCoreData.podspec
+++ b/RxCoreData.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
     s.social_media_url      = "https://twitter.com/scotteg"
 
     s.ios.deployment_target = '9.3'
-    s.osx.deployment_target = '10.11'
+    s.osx.deployment_target = '10.12'
     s.watchos.deployment_target = '2.0'
     s.tvos.deployment_target = '9.0'
 


### PR DESCRIPTION
Sorry I missed this with my previous PR.

It turns out [`NSFetchedResultsController` support in macOS was added in Sierra](https://developer.apple.com/documentation/coredata/nsfetchedresultscontroller).  This caused a compilation error when including this library in a Mac project!

I did try adding `@available(macOS 10.12, *)` statements in the relevant bits of the codebase, but by doing this, practically the entire library was being excluded from El Capitan users.  So I reckon the best course of action would be just to bump up the macOS version requirement in the podspec.