### PR TITLE
Add mac 🖥, tv 📺 & watch ⌚️ support for Carthage

### DIFF
--- a/RxCoreData.xcodeproj/project.pbxproj
+++ b/RxCoreData.xcodeproj/project.pbxproj
@@ -8,28 +8,54 @@
 
 /* Begin PBXBuildFile section */
 		5A017DD41D7D6F560027384A /* RxCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A017DD31D7D6F560027384A /* RxCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A0A91C31D7D75B9006E8CBD /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A0A91C21D7D75B9006E8CBD /* CoreData.framework */; };
-		5A0A91C51D7D75BF006E8CBD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A0A91C41D7D75BF006E8CBD /* Foundation.framework */; };
 		5A2FAD551D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD501D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift */; };
 		5A2FAD561D7D6F73007DECCB /* FetchedResultsControllerSectionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD511D7D6F73007DECCB /* FetchedResultsControllerSectionObserver.swift */; };
 		5A2FAD571D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD521D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift */; };
 		5A2FAD581D7D6F73007DECCB /* Persistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD531D7D6F73007DECCB /* Persistable.swift */; };
-		5A2FAD5B1D7D6F84007DECCB /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A2FAD591D7D6F84007DECCB /* RxCocoa.framework */; };
-		5A2FAD5C1D7D6F84007DECCB /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A2FAD5A1D7D6F84007DECCB /* RxSwift.framework */; };
+		F400B2C62040BED6003F5030 /* FetchedResultsControllerSectionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD511D7D6F73007DECCB /* FetchedResultsControllerSectionObserver.swift */; };
+		F400B2C72040BED6003F5030 /* FetchedResultsControllerControllerEntityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD501D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift */; };
+		F400B2C82040BED6003F5030 /* Persistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD531D7D6F73007DECCB /* Persistable.swift */; };
+		F400B2C92040BED6003F5030 /* NSManagedObjectContext+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD521D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift */; };
+		F400B2CC2040BED6003F5030 /* RxCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A017DD31D7D6F560027384A /* RxCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F400B2D52040BEEA003F5030 /* FetchedResultsControllerSectionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD511D7D6F73007DECCB /* FetchedResultsControllerSectionObserver.swift */; };
+		F400B2D62040BEEA003F5030 /* FetchedResultsControllerControllerEntityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD501D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift */; };
+		F400B2D72040BEEA003F5030 /* Persistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD531D7D6F73007DECCB /* Persistable.swift */; };
+		F400B2D82040BEEA003F5030 /* NSManagedObjectContext+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD521D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift */; };
+		F400B2DB2040BEEA003F5030 /* RxCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A017DD31D7D6F560027384A /* RxCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F400B2E42040BEF4003F5030 /* FetchedResultsControllerSectionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD511D7D6F73007DECCB /* FetchedResultsControllerSectionObserver.swift */; };
+		F400B2E52040BEF4003F5030 /* FetchedResultsControllerControllerEntityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD501D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift */; };
+		F400B2E62040BEF4003F5030 /* Persistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD531D7D6F73007DECCB /* Persistable.swift */; };
+		F400B2E72040BEF4003F5030 /* NSManagedObjectContext+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FAD521D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift */; };
+		F400B2EA2040BEF4003F5030 /* RxCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A017DD31D7D6F560027384A /* RxCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F470C7072040C21100B43981 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C6FA2040C1DA00B43981 /* RxCocoa.framework */; };
+		F470C7082040C21100B43981 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C6FB2040C1DA00B43981 /* RxSwift.framework */; };
+		F470C7092040C21700B43981 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C7042040C1DA00B43981 /* RxCocoa.framework */; };
+		F470C70A2040C21700B43981 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C7052040C1DA00B43981 /* RxSwift.framework */; };
+		F470C70B2040C21C00B43981 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C6E22040C1DA00B43981 /* RxCocoa.framework */; };
+		F470C70C2040C21C00B43981 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C6E32040C1DA00B43981 /* RxSwift.framework */; };
+		F470C70D2040C22200B43981 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C6EB2040C1DA00B43981 /* RxCocoa.framework */; };
+		F470C70E2040C22200B43981 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F470C6ED2040C1DA00B43981 /* RxSwift.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		5A017DD01D7D6F550027384A /* RxCoreData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCoreData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A017DD31D7D6F560027384A /* RxCoreData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxCoreData.h; sourceTree = "<group>"; };
 		5A017DD51D7D6F560027384A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		5A0A91C21D7D75B9006E8CBD /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
-		5A0A91C41D7D75BF006E8CBD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		5A2FAD501D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedResultsControllerControllerEntityObserver.swift; sourceTree = "<group>"; };
 		5A2FAD511D7D6F73007DECCB /* FetchedResultsControllerSectionObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedResultsControllerSectionObserver.swift; sourceTree = "<group>"; };
 		5A2FAD521D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Rx.swift"; sourceTree = "<group>"; };
 		5A2FAD531D7D6F73007DECCB /* Persistable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Persistable.swift; sourceTree = "<group>"; };
-		5A2FAD591D7D6F84007DECCB /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
-		5A2FAD5A1D7D6F84007DECCB /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
+		F400B2D12040BED6003F5030 /* RxCoreData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCoreData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F400B2E02040BEEA003F5030 /* RxCoreData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCoreData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F400B2EF2040BEF4003F5030 /* RxCoreData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCoreData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F470C6E22040C1DA00B43981 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxCocoa.framework; sourceTree = "<group>"; };
+		F470C6E32040C1DA00B43981 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxSwift.framework; sourceTree = "<group>"; };
+		F470C6EB2040C1DA00B43981 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxCocoa.framework; sourceTree = "<group>"; };
+		F470C6ED2040C1DA00B43981 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxSwift.framework; sourceTree = "<group>"; };
+		F470C6FA2040C1DA00B43981 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxCocoa.framework; sourceTree = "<group>"; };
+		F470C6FB2040C1DA00B43981 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxSwift.framework; sourceTree = "<group>"; };
+		F470C7042040C1DA00B43981 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxCocoa.framework; sourceTree = "<group>"; };
+		F470C7052040C1DA00B43981 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxSwift.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,10 +63,35 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5A0A91C51D7D75BF006E8CBD /* Foundation.framework in Frameworks */,
-				5A0A91C31D7D75B9006E8CBD /* CoreData.framework in Frameworks */,
-				5A2FAD5B1D7D6F84007DECCB /* RxCocoa.framework in Frameworks */,
-				5A2FAD5C1D7D6F84007DECCB /* RxSwift.framework in Frameworks */,
+				F470C7072040C21100B43981 /* RxCocoa.framework in Frameworks */,
+				F470C7082040C21100B43981 /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2CA2040BED6003F5030 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F470C7092040C21700B43981 /* RxCocoa.framework in Frameworks */,
+				F470C70A2040C21700B43981 /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2D92040BEEA003F5030 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F470C70B2040C21C00B43981 /* RxCocoa.framework in Frameworks */,
+				F470C70C2040C21C00B43981 /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2E82040BEF4003F5030 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F470C70D2040C22200B43981 /* RxCocoa.framework in Frameworks */,
+				F470C70E2040C22200B43981 /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -50,11 +101,8 @@
 		5A017DC61D7D6F550027384A = {
 			isa = PBXGroup;
 			children = (
-				5A0A91C41D7D75BF006E8CBD /* Foundation.framework */,
-				5A0A91C21D7D75B9006E8CBD /* CoreData.framework */,
-				5A2FAD591D7D6F84007DECCB /* RxCocoa.framework */,
-				5A2FAD5A1D7D6F84007DECCB /* RxSwift.framework */,
 				5A017DD21D7D6F550027384A /* RxCoreData */,
+				F400B2C12040BEBD003F5030 /* Frameworks */,
 				5A017DD11D7D6F550027384A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -63,6 +111,9 @@
 			isa = PBXGroup;
 			children = (
 				5A017DD01D7D6F550027384A /* RxCoreData.framework */,
+				F400B2D12040BED6003F5030 /* RxCoreData.framework */,
+				F400B2E02040BEEA003F5030 /* RxCoreData.framework */,
+				F400B2EF2040BEF4003F5030 /* RxCoreData.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -88,6 +139,57 @@
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
 		};
+		F400B2C12040BEBD003F5030 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F470C6EF2040C1DA00B43981 /* iOS */,
+				F470C6FE2040C1DA00B43981 /* Mac */,
+				F470C6D92040C1DA00B43981 /* tvOS */,
+				F470C6E52040C1DA00B43981 /* watchOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F470C6D92040C1DA00B43981 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				F470C6E22040C1DA00B43981 /* RxCocoa.framework */,
+				F470C6E32040C1DA00B43981 /* RxSwift.framework */,
+			);
+			name = tvOS;
+			path = Carthage/Build/tvOS;
+			sourceTree = "<group>";
+		};
+		F470C6E52040C1DA00B43981 /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				F470C6EB2040C1DA00B43981 /* RxCocoa.framework */,
+				F470C6ED2040C1DA00B43981 /* RxSwift.framework */,
+			);
+			name = watchOS;
+			path = Carthage/Build/watchOS;
+			sourceTree = "<group>";
+		};
+		F470C6EF2040C1DA00B43981 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				F470C6FA2040C1DA00B43981 /* RxCocoa.framework */,
+				F470C6FB2040C1DA00B43981 /* RxSwift.framework */,
+			);
+			name = iOS;
+			path = Carthage/Build/iOS;
+			sourceTree = "<group>";
+		};
+		F470C6FE2040C1DA00B43981 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				F470C7042040C1DA00B43981 /* RxCocoa.framework */,
+				F470C7052040C1DA00B43981 /* RxSwift.framework */,
+			);
+			name = Mac;
+			path = Carthage/Build/Mac;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -99,12 +201,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F400B2CB2040BED6003F5030 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F400B2CC2040BED6003F5030 /* RxCoreData.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2DA2040BEEA003F5030 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F400B2DB2040BEEA003F5030 /* RxCoreData.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2E92040BEF4003F5030 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F400B2EA2040BEF4003F5030 /* RxCoreData.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		5A017DCF1D7D6F550027384A /* RxCoreData */ = {
+		5A017DCF1D7D6F550027384A /* RxCoreData iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5A017DD81D7D6F560027384A /* Build configuration list for PBXNativeTarget "RxCoreData" */;
+			buildConfigurationList = 5A017DD81D7D6F560027384A /* Build configuration list for PBXNativeTarget "RxCoreData iOS" */;
 			buildPhases = (
 				5A017DCB1D7D6F550027384A /* Sources */,
 				5A017DCC1D7D6F550027384A /* Frameworks */,
@@ -115,9 +241,63 @@
 			);
 			dependencies = (
 			);
-			name = RxCoreData;
+			name = "RxCoreData iOS";
 			productName = RxCoreData;
 			productReference = 5A017DD01D7D6F550027384A /* RxCoreData.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F400B2C42040BED6003F5030 /* RxCoreData macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F400B2CE2040BED6003F5030 /* Build configuration list for PBXNativeTarget "RxCoreData macOS" */;
+			buildPhases = (
+				F400B2C52040BED6003F5030 /* Sources */,
+				F400B2CA2040BED6003F5030 /* Frameworks */,
+				F400B2CB2040BED6003F5030 /* Headers */,
+				F400B2CD2040BED6003F5030 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RxCoreData macOS";
+			productName = RxCoreData;
+			productReference = F400B2D12040BED6003F5030 /* RxCoreData.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F400B2D32040BEEA003F5030 /* RxCoreData tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F400B2DD2040BEEA003F5030 /* Build configuration list for PBXNativeTarget "RxCoreData tvOS" */;
+			buildPhases = (
+				F400B2D42040BEEA003F5030 /* Sources */,
+				F400B2D92040BEEA003F5030 /* Frameworks */,
+				F400B2DA2040BEEA003F5030 /* Headers */,
+				F400B2DC2040BEEA003F5030 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RxCoreData tvOS";
+			productName = RxCoreData;
+			productReference = F400B2E02040BEEA003F5030 /* RxCoreData.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F400B2E22040BEF4003F5030 /* RxCoreData watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F400B2EC2040BEF4003F5030 /* Build configuration list for PBXNativeTarget "RxCoreData watchOS" */;
+			buildPhases = (
+				F400B2E32040BEF4003F5030 /* Sources */,
+				F400B2E82040BEF4003F5030 /* Frameworks */,
+				F400B2E92040BEF4003F5030 /* Headers */,
+				F400B2EB2040BEF4003F5030 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RxCoreData watchOS";
+			productName = RxCoreData;
+			productReference = F400B2EF2040BEF4003F5030 /* RxCoreData.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -147,13 +327,37 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				5A017DCF1D7D6F550027384A /* RxCoreData */,
+				5A017DCF1D7D6F550027384A /* RxCoreData iOS */,
+				F400B2C42040BED6003F5030 /* RxCoreData macOS */,
+				F400B2D32040BEEA003F5030 /* RxCoreData tvOS */,
+				F400B2E22040BEF4003F5030 /* RxCoreData watchOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		5A017DCE1D7D6F550027384A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2CD2040BED6003F5030 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2DC2040BEEA003F5030 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2EB2040BEF4003F5030 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -171,6 +375,39 @@
 				5A2FAD551D7D6F73007DECCB /* FetchedResultsControllerControllerEntityObserver.swift in Sources */,
 				5A2FAD581D7D6F73007DECCB /* Persistable.swift in Sources */,
 				5A2FAD571D7D6F73007DECCB /* NSManagedObjectContext+Rx.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2C52040BED6003F5030 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F400B2C62040BED6003F5030 /* FetchedResultsControllerSectionObserver.swift in Sources */,
+				F400B2C72040BED6003F5030 /* FetchedResultsControllerControllerEntityObserver.swift in Sources */,
+				F400B2C82040BED6003F5030 /* Persistable.swift in Sources */,
+				F400B2C92040BED6003F5030 /* NSManagedObjectContext+Rx.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2D42040BEEA003F5030 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F400B2D52040BEEA003F5030 /* FetchedResultsControllerSectionObserver.swift in Sources */,
+				F400B2D62040BEEA003F5030 /* FetchedResultsControllerControllerEntityObserver.swift in Sources */,
+				F400B2D72040BEEA003F5030 /* Persistable.swift in Sources */,
+				F400B2D82040BEEA003F5030 /* NSManagedObjectContext+Rx.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F400B2E32040BEF4003F5030 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F400B2E42040BEF4003F5030 /* FetchedResultsControllerSectionObserver.swift in Sources */,
+				F400B2E52040BEF4003F5030 /* FetchedResultsControllerControllerEntityObserver.swift in Sources */,
+				F400B2E62040BEF4003F5030 /* Persistable.swift in Sources */,
+				F400B2E72040BEF4003F5030 /* NSManagedObjectContext+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -226,6 +463,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = RxCoreData;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -276,6 +514,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxCoreData;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -300,13 +539,12 @@
 				);
 				INFOPLIST_FILE = RxCoreData/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -325,13 +563,166 @@
 				);
 				INFOPLIST_FILE = RxCoreData/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F400B2CF2040BED6003F5030 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = RxCoreData/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		F400B2D02040BED6003F5030 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = RxCoreData/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		F400B2DE2040BEEA003F5030 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = RxCoreData/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		F400B2DF2040BEEA003F5030 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = RxCoreData/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		F400B2ED2040BEF4003F5030 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = RxCoreData/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		F400B2EE2040BEF4003F5030 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = RxCoreData/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.rxswiftcommunity.RxCoreData;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -347,11 +738,38 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5A017DD81D7D6F560027384A /* Build configuration list for PBXNativeTarget "RxCoreData" */ = {
+		5A017DD81D7D6F560027384A /* Build configuration list for PBXNativeTarget "RxCoreData iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				5A017DD91D7D6F560027384A /* Debug */,
 				5A017DDA1D7D6F560027384A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F400B2CE2040BED6003F5030 /* Build configuration list for PBXNativeTarget "RxCoreData macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F400B2CF2040BED6003F5030 /* Debug */,
+				F400B2D02040BED6003F5030 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F400B2DD2040BEEA003F5030 /* Build configuration list for PBXNativeTarget "RxCoreData tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F400B2DE2040BEEA003F5030 /* Debug */,
+				F400B2DF2040BEEA003F5030 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F400B2EC2040BEF4003F5030 /* Build configuration list for PBXNativeTarget "RxCoreData watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F400B2ED2040BEF4003F5030 /* Debug */,
+				F400B2EE2040BEF4003F5030 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData iOS.xcscheme
+++ b/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData iOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5A017DCF1D7D6F550027384A"
+               BuildableName = "RxCoreData.framework"
+               BlueprintName = "RxCoreData iOS"
+               ReferencedContainer = "container:RxCoreData.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5A017DCF1D7D6F550027384A"
+            BuildableName = "RxCoreData.framework"
+            BlueprintName = "RxCoreData iOS"
+            ReferencedContainer = "container:RxCoreData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5A017DCF1D7D6F550027384A"
+            BuildableName = "RxCoreData.framework"
+            BlueprintName = "RxCoreData iOS"
+            ReferencedContainer = "container:RxCoreData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData macOS.xcscheme
+++ b/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData macOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F400B2C42040BED6003F5030"
+               BuildableName = "RxCoreData.framework"
+               BlueprintName = "RxCoreData macOS"
+               ReferencedContainer = "container:RxCoreData.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F400B2C42040BED6003F5030"
+            BuildableName = "RxCoreData.framework"
+            BlueprintName = "RxCoreData macOS"
+            ReferencedContainer = "container:RxCoreData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F400B2C42040BED6003F5030"
+            BuildableName = "RxCoreData.framework"
+            BlueprintName = "RxCoreData macOS"
+            ReferencedContainer = "container:RxCoreData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData tvOS.xcscheme
+++ b/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData tvOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F400B2D32040BEEA003F5030"
+               BuildableName = "RxCoreData.framework"
+               BlueprintName = "RxCoreData tvOS"
+               ReferencedContainer = "container:RxCoreData.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F400B2D32040BEEA003F5030"
+            BuildableName = "RxCoreData.framework"
+            BlueprintName = "RxCoreData tvOS"
+            ReferencedContainer = "container:RxCoreData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F400B2D32040BEEA003F5030"
+            BuildableName = "RxCoreData.framework"
+            BlueprintName = "RxCoreData tvOS"
+            ReferencedContainer = "container:RxCoreData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData watchOS.xcscheme
+++ b/RxCoreData.xcodeproj/xcshareddata/xcschemes/RxCoreData watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5A017DCF1D7D6F550027384A"
+               BlueprintIdentifier = "F400B2E22040BEF4003F5030"
                BuildableName = "RxCoreData.framework"
-               BlueprintName = "RxCoreData"
+               BlueprintName = "RxCoreData watchOS"
                ReferencedContainer = "container:RxCoreData.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,9 +47,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5A017DCF1D7D6F550027384A"
+            BlueprintIdentifier = "F400B2E22040BEF4003F5030"
             BuildableName = "RxCoreData.framework"
-            BlueprintName = "RxCoreData"
+            BlueprintName = "RxCoreData watchOS"
             ReferencedContainer = "container:RxCoreData.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -65,9 +65,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5A017DCF1D7D6F550027384A"
+            BlueprintIdentifier = "F400B2E22040BEF4003F5030"
             BuildableName = "RxCoreData.framework"
-            BlueprintName = "RxCoreData"
+            BlueprintName = "RxCoreData watchOS"
             ReferencedContainer = "container:RxCoreData.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/RxCoreData/RxCoreData.h
+++ b/RxCoreData/RxCoreData.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 RxSwiftCommunity. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for RxCoreData.
 FOUNDATION_EXPORT double RxCoreDataVersionNumber;

--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
This PR builds on my previous contributions and adds cross platform Carthage support to the project.

I've followed the convention used by RxOptional, Actions and other RxSwiftCommunity projects by having a scheme and target per platform.  As annoying as it is adding any new source files to all 4 targets, it seems like it's not possible to have a single target and include all of the flavours of RxSwift - however, I'd be more than happy to be corrected.

Finally, I've removed `_Pods.xcodeproj` as it's a dead symbolic link.